### PR TITLE
 DELIA-66975: ASAN init failure

### DIFF
--- a/ccec/include/ccec/Operands.hpp
+++ b/ccec/include/ccec/Operands.hpp
@@ -272,8 +272,8 @@ public:
 		MAX_LEN = 3,
 	};
 
-    Language(const char *str) : CECBytes((const uint8_t*)str, MAX_LEN) {
-        validate();
+    Language(const char *str) : CECBytes((const uint8_t*)str, strlen(str)) {
+        Assert(strlen(str) <= MAX_LEN);
     }
 
     Language(const CECFrame &frame, size_t startPos) : CECBytes(frame, startPos, MAX_LEN) {


### PR DESCRIPTION
Reason for change: Update to make sure we do not try and and assign str if the buf is too small. Test Procedure:
Risks: low
Priority: P1

Change-Id: Icfcad2ab1dadcc143d93c1a1f18b93319b6a36ee 
Signed-off-by:Hayden Gfeller <Hayden_Gfeller@comcast.com>