### PR TITLE
XIONE-15405: HDMI CEC Logical address update

### DIFF
--- a/ccec/include/ccec/Connection.hpp
+++ b/ccec/include/ccec/Connection.hpp
@@ -80,7 +80,7 @@ public:
 		return source;
 	}
 	
-	void setSource(LogicalAddress &from) {
+	void setSource(const LogicalAddress &from) {
 		source = from;
 	}
 


### PR DESCRIPTION
Reason for change: Convert non-const lvalue to const
                   to avoid binding issues

Test Procedure: build and verify
Risks: Medium
Priority: P1
Signed-off-by: Srigayathry Pugazhenthi<srigayathry.pugazhenthi@sky.uk>